### PR TITLE
lmk disable debug and fast_run as well

### DIFF
--- a/rootdir/etc/init.qcom.power.rc
+++ b/rootdir/etc/init.qcom.power.rc
@@ -161,8 +161,10 @@ on enable-low-power
     write /sys/module/process_reclaim/parameters/swap_opt_eff 30
 
     write /sys/module/lowmemorykiller/parameters/enable_adaptive_lmk 1
-    write /sys/module/lowmemorykiller/parameters/vmpressure_file_min 53059
-
+    write /sys/module/lowmemorykiller/parameters/vmpressure_file_min 81250
+    write /sys/module/lowmemorykiller/parameters/debug_level 0
+    write /sys/module/lowmemorykiller/parameters/lmk_fast_run 0
+    
     write /proc/sys/kernel/sched_boost 0
 
     # Set perfd properties


### PR DESCRIPTION
this is a standard on most devices. and the min vm file pressure is what is being used on other snapdragon 6XX devices. 