### PR TITLE
disable discard on userdata

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -8,7 +8,7 @@
 #<src>                                      <mnt_point>         <type>  <mnt_flags and options>                                            <fs_mgr_flags>
 /dev/block/bootdevice/by-name/system         /system             ext4    ro,barrier=1                                                       wait
 /dev/block/bootdevice/by-name/userdata       /data               f2fs    rw,nosuid,nodev,noatime,nodiratime,inline_xattr,inline_data        wait,check,formattable,encryptable=/dev/block/bootdevice/by-name/metadata
-/dev/block/bootdevice/by-name/userdata       /data               ext4    nosuid,nodev,barrier=1,noauto_da_alloc,discard                     wait,check,formattable,encryptable=/dev/block/bootdevice/by-name/metadata
+/dev/block/bootdevice/by-name/userdata       /data               ext4    nosuid,nodev,barrier=1,noauto_da_alloc                             wait,check,formattable,encryptable=/dev/block/bootdevice/by-name/metadata
 /dev/block/bootdevice/by-name/cache          /cache              ext4    rw,nosuid,nodev,noatime,barrier=1,data=ordered                     wait,check,formattable
 /dev/block/bootdevice/by-name/fsg            /fsg                ext4    ro,nosuid,nodev,barrier=0          wait
 /dev/block/bootdevice/by-name/modem          /firmware           ext4    ro,nosuid,nodev,barrier=0      wait


### PR DESCRIPTION
Android trims by it self. This has effectively been useless since kitkat when full trim support was introduced