### PR TITLE
force hal1 for snapchat

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -148,7 +148,7 @@ camera.lowpower.record.enable=1
 camera.display.lmax=1280x720
 camera.display.umax=1920x1080
 persist.camera.HAL3.enabled=1
-camera.hal1.packagelist=com.skype.raider,com.whatsapp,com.tencent.mm,com.google.android.GoogleCamera
+camera.hal1.packagelist=com.skype.raider,com.whatsapp,com.tencent.mm,com.google.android.GoogleCamera,com.snapchat.android
 
 # CNE
 persist.cne.feature=1


### PR DESCRIPTION
without this snapchat lags and crashes 9/10 times you open it. happens both on Marshmallow and  Nougat.