### PR TITLE
set dalvik heap and hwui memory

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -25,6 +25,10 @@ DEVICE_PACKAGE_OVERLAYS += $(LOCAL_PATH)/overlay
 # Screen density
 PRODUCT_AAPT_PREF_CONFIG := xxhdpi
 
+$(call inherit-product, frameworks/native/build/phone-xxhdpi-2048-dalvik-heap.mk)
+
+$(call inherit-product, frameworks/native/build/phone-xxhdpi-2048-hwui-memory.mk)
+
 # Device was launched with M
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.product.first_api_level=23


### PR DESCRIPTION
I've thought we were having memory leak issues on this device for the longest time because after about a day of up time performance goes to shit. but actually its because these were not set so it was using the default which are too small and after a short amount of up time device performance goes to absolute shit